### PR TITLE
feat(restore): add --strict-hash option for hash verification

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -34,9 +34,11 @@ python convert_to_utf8.py <file> --encoding <encoding>
 ```json
 {
   "original_file": "example.txt",
+  "output_file": "example.txt",
   "original_encoding": "cp932",
   "original_size": 1024,
   "original_hash": "sha256hash...",
+  "converted_hash": "sha256hash...",
   "backup_path": "example.txt.cp932.bak",
   "line_ending": "CRLF",
   "converted_at": "2026-02-03T10:30:00"
@@ -64,6 +66,12 @@ python restore_encoding.py <file>
 | `--output`, `-o` | 出力先（デフォルト: 上書き） |
 | `--errors` | エラー処理: strict/replace/backslashreplace/xmlcharrefreplace |
 | `--keep-backup` | バックアップを保持 |
+| `--strict-hash` | ハッシュ不一致をエラーにする（`--force`で上書き） |
+| `--force`, `-f` | ハッシュ不一致でも強制的に続行（主に`--strict-hash`用） |
+
+**ハッシュ検証**:
+- デフォルト: ハッシュ不一致でも警告して続行
+- `--strict-hash`: ハッシュ不一致でエラー（`--force`で続行可能）
 
 **エラー処理オプション**:
 - `strict`: 変換不可能な文字でエラー（デフォルト）

--- a/skills/charenc/SKILL.md
+++ b/skills/charenc/SKILL.md
@@ -65,6 +65,7 @@ This restores cp932 encoding and removes backup/metadata.
 | `-o, --output` | Output path (default: overwrite) |
 | `--errors` | Error handling: strict/replace/backslashreplace |
 | `--keep-backup` | Keep backup and metadata |
+| `--strict-hash` | Fail on hash mismatch (override with `--force`) |
 | `-f, --force` | Force restore even if file hash doesn't match |
 
 ## Error Handling
@@ -81,11 +82,17 @@ python scripts/restore_encoding.py file.txt --errors backslashreplace
 
 ## Hash Verification
 
-When restoring, the tool verifies that the file hasn't been modified unexpectedly by comparing SHA256 hashes. If the hash doesn't match (e.g., the file was edited outside the normal workflow):
+When restoring, the tool can verify the file content by comparing SHA256 hashes.
+
+- Default: if the hash doesn't match (e.g., you edited the file), restore continues with a warning.
+- Strict mode: use `--strict-hash` to fail on hash mismatch (can be overridden with `--force`).
 
 ```bash
-# Force restore despite hash mismatch
-python scripts/restore_encoding.py file.txt --force
+# Fail on hash mismatch
+python scripts/restore_encoding.py file.txt --strict-hash
+
+# Override strict mode
+python scripts/restore_encoding.py file.txt --strict-hash --force
 ```
 
 ## Supported Encodings


### PR DESCRIPTION
## Summary

Add a new \--strict-hash\ option to \estore_encoding.py\ that fails on hash mismatch instead of just warning.

## Changes

- **restore_encoding.py**
  - Add \strict_hash\ parameter to \estore_encoding()\ function
  - Return \xpected_hash\ and \current_hash\ in result when hash mismatch occurs
  - Add \--strict-hash\ CLI option (fails on hash mismatch unless \--force\)
  - Update \--force\ help text to reference \--strict-hash\

- **docs/specification.md**
  - Added \output_file\ and \converted_hash\ to metadata format
  - Documented \--strict-hash\ and \--force\ options
  - Added hash verification behavior section

- **skills/charenc/SKILL.md**
  - Added \--strict-hash\ option to reference table
  - Added Hash Verification section with usage examples

## Behavior

| Mode | Hash Mismatch Behavior |
|------|----------------------|
| Default | Warning, continue |
| \--strict-hash\ | Error, abort |
| \--strict-hash --force\ | Warning, continue |
