### PR TITLE
fix: スキルファイルのYAML構文を修正

### DIFF
--- a/skills/charenc/SKILL.md
+++ b/skills/charenc/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: charenc
-description: |
-  Character encoding conversion for editing non-UTF-8 files with AI agents.
-  Use when: (1) Editing files with Japanese characters that appear garbled,
-  (2) Working with legacy codebases using cp932/Shift-JIS/EUC-JP encoding,
-  (3) Converting file encodings before editing and restoring after.
-  Workflow: convert to UTF-8 -> edit -> restore original encoding.
+description: "Character encoding conversion for editing non-UTF-8 files with AI agents. Use when: (1) Editing files with Japanese characters that appear garbled, (2) Working with legacy codebases using cp932/Shift-JIS/EUC-JP encoding, (3) Converting file encodings before editing and restoring after. Workflow: convert to UTF-8 -> edit -> restore original encoding."
 ---
 
 # Character Encoding Conversion


### PR DESCRIPTION
## 概要
YAML フロントマターの複数行文字列構文（`|`）がスキルファイルパーサーでサポートされていないため、`description`を単一行の引用符付き文字列に変更しました。

## テスト方法
- VSCode の診断エラーが解消されることを確認
- スキルの機能が正常に動作することを確認