### PR TITLE
fix(restore): handle invalid UTF-8 decode errors

### DIFF
--- a/skills/charenc/scripts/restore_encoding.py
+++ b/skills/charenc/scripts/restore_encoding.py
@@ -89,6 +89,12 @@ def restore_encoding(
     try:
         with open(path, 'r', encoding='utf-8', newline='') as f:
             text = f.read()
+    except UnicodeDecodeError as e:
+        return {
+            "status": "error",
+            "error": f"Invalid UTF-8 content: {e}",
+            "hint": "The file is not valid UTF-8. It may be corrupted or not converted with convert_to_utf8.py."
+        }
     except IOError as e:
         return {"status": "error", "error": f"Cannot read file: {e}"}
 


### PR DESCRIPTION
## Summary
- catch UnicodeDecodeError when reading restored file as UTF-8
- return structured JSON error instead of crashing with traceback
- include hint for likely cause (corruption or not converted via convert_to_utf8.py)

## Validation
- python -m py_compile skills/charenc/scripts/restore_encoding.py
- verified invalid UTF-8 input now returns status: error JSON